### PR TITLE
Provide a convenient `replication-delay` method in client

### DIFF
--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -15,6 +15,12 @@ module Freno
       yield self if block_given?
     end
 
+    def replication_delay(app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
+      options.merge!({verb: :get})
+      res = check(app: app, store_type: store_type, store_name: store_name, options: options)
+      res.body["Value"]
+    end
+
     def check(app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
       Requests::Check.new(faraday, app: app, store_type: store_type, store_name: store_name, options: options).perform
     end

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -5,6 +5,15 @@ class Freno::ClientTest < Freno::Client::Test
     refute_nil ::Freno::Client::VERSION
   end
 
+  def test_replication_delay
+    client = stubbed_client do |stub|
+      stub.get("/check/github/mysql/main") { |env| [200, {}, <<-BODY] }
+        {"StatusCode":200,"Value":0.025173,"Threshold":1,"Message":""}
+      BODY
+    end
+    assert_equal 0.025173, client.replication_delay
+  end
+
   def test_check_succeeds
     client = stubbed_client do |stub|
       stub.head("/check/github/mysql/main") { |env| [200, {}, nil] }


### PR DESCRIPTION
Replication delay is the de-facto metric used by freno to determine
whether read or write access to a db cluster should be throttled.

Despite the following is said in the
[docs](https://github.com/github/freno/blob/master/doc/http.md#get-method):

> GET and HEAD respond with same status codes. But GET requests compute
and return additional data. Automated requests should not be interested
in this data; the status code is what should guide the clients. However
humans or manual requests may benefit from extra information supplied by
the GET request.

A computer might also be interested in knowing the raw value of
replication delay to, for instance, route DB operations to replicas
depending on when the last write happened on a primary server.