### PR TITLE
Add linting to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,12 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 before_install: gem install bundler -v 1.14.6
-script: bundle exec script/cibuild
+script:
+  - bundle exec script/cibuild
+  - bundle exec script/cibuild-lint

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rubocop", require: false
+group :test do
+  gem "rubocop", require: false
+end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Freno::Client
+# Freno Client [![Build Status](https://travis-ci.org/github/freno-client.svg)](https://travis-ci.org/github/freno-client)
 
 A ruby client for [Freno](https://github.com/github/freno): the cooperative, highly available throttler service.
 


### PR DESCRIPTION
With this PR, [travis](https://travis-ci.org/github/freno-client) will run rubocop as part of the build to check for style offenses.