### PR TITLE
Wrap any error happening during a request to freno in a Freno::Error

### DIFF
--- a/lib/freno/client/errors.rb
+++ b/lib/freno/client/errors.rb
@@ -1,0 +1,3 @@
+module Freno
+  Error = Class.new(StandardError)
+end

--- a/lib/freno/client/request.rb
+++ b/lib/freno/client/request.rb
@@ -1,5 +1,6 @@
 require_relative "preconditions"
 require_relative "result"
+require_relative "errors"
 
 module Freno
   class Client
@@ -24,14 +25,13 @@ module Freno
       end
 
       def perform
-        begin
-          response = request(verb, path)
-        rescue Faraday::TimeoutError => ex
-          raise ex if raise_on_timeout
-          Result.from_meaning(:request_timeout)
-        else
-          process_response(response)
-        end
+        response = request(verb, path)
+        process_response(response)
+      rescue Faraday::TimeoutError => ex
+        raise Freno::Error.new(ex) if raise_on_timeout
+        Result.from_meaning(:request_timeout)
+      rescue => ex
+        raise Freno::Error.new(ex)
       end
 
       protected

--- a/lib/freno/client/version.rb
+++ b/lib/freno/client/version.rb
@@ -1,5 +1,5 @@
 module Freno
   class Client
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/test/freno/client/requests/check_read_test.rb
+++ b/test/freno/client/requests/check_read_test.rb
@@ -110,7 +110,7 @@ class Freno::Client::Requests::CheckReadTest < Freno::Client::Test
 
     request = CheckRead.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", threshold: 0.5)
 
-    ex = assert_raises Faraday::TimeoutError do
+    ex = assert_raises Freno::Error do
       request.perform
     end
 

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -65,7 +65,7 @@ class Freno::ClientTest < Freno::Client::Test
       freno.default_app        = :github
     end
 
-    ex = assert_raises Faraday::TimeoutError do
+    ex = assert_raises Freno::Error do
       client.check_read(threshold: 0.5) == :request_timeout
     end
 


### PR DESCRIPTION
This PR wraps any error happening during the request lifecycle in a `Freno::Error` to allow users of this gem to handle error cases better.

cc @github/platform-data @shlomi-noach 