### PR TITLE
Prevent decorator reuse

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,19 +7,10 @@ Bundler/DuplicatedGem:
 Bundler/OrderedGems:
   Enabled: true
 
-Lint/BlockAlignment:
-  Enabled: true
-
 Lint/CircularArgumentReference:
   Enabled: true
 
-Lint/ConditionPosition:
-  Enabled: true
-
 Lint/Debugger:
-  Enabled: true
-
-Lint/DefEndAlignment:
   Enabled: true
 
 Lint/DeprecatedClassMethods:
@@ -46,13 +37,13 @@ Lint/EndInMethod:
 Lint/EmptyInterpolation:
   Enabled: true
 
-Lint/EndAlignment:
-  Enabled: false
-
 Lint/EnsureReturn:
   Enabled: true
 
 Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FlipFlop:
   Enabled: true
 
 Lint/FormatParameterMismatch:
@@ -61,9 +52,6 @@ Lint/FormatParameterMismatch:
 Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19
-
-Lint/LiteralInCondition:
-  Enabled: true
 
 Lint/LiteralInInterpolation:
   Enabled: true
@@ -87,9 +75,6 @@ Lint/StringConversionInInterpolation:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-
-Lint/UnneededDisable:
   Enabled: true
 
 Lint/UnneededSplatExpansion:
@@ -167,9 +152,6 @@ Performance/EndWith:
 Performance/FlatMap:
   Enabled: true
 
-Performance/HashEachMethods:
-  Enabled: true
-
 Performance/LstripRstrip:
   Enabled: true
 
@@ -210,9 +192,6 @@ Style/BeginBlock:
 Style/BlockComments:
   Enabled: true
 
-Layout/BlockEndNewline:
-  Enabled: true
-
 Style/CaseEquality:
   Enabled: true
 
@@ -231,13 +210,19 @@ Style/DefWithParentheses:
 Style/EndBlock:
   Enabled: true
 
-Layout/EndOfLine:
-  Enabled: true
-
-Style/FlipFlop:
-  Enabled: true
-
 Style/For:
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Enabled: true
+
+Layout/ConditionPosition:
+  Enabled: true
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/EndOfLine:
   Enabled: true
 
 Layout/InitialIndentation:
@@ -264,6 +249,12 @@ Style/Not:
 Style/OneLineConditional:
   Enabled: true
 
+Layout/BlockAlignment:
+  Enabled: true
+
+Layout/DefEndAlignment:
+  Enabled: true
+
 Layout/SpaceAfterMethodName:
   Enabled: true
 
@@ -286,9 +277,6 @@ Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
 Layout/SpaceInsideArrayPercentLiteral:
-  Enabled: true
-
-Layout/SpaceInsideBrackets:
   Enabled: true
 
 Layout/SpaceInsideParens:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,9 +62,6 @@ Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19
 
-Lint/InvalidCharacterLiteral:
-  Enabled: true
-
 Lint/LiteralInCondition:
   Enabled: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
+  - 2.5
   - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
-  fast_finish: true
-before_install: gem install bundler -v 1.14.6
 script:
-  - bundle exec script/cibuild
-  - bundle exec script/cibuild-lint
+  - bundle exec rake
+  - bundle exec rubocop

--- a/freno-client.gemspec
+++ b/freno-client.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest", "~> 5"
   spec.add_development_dependency "faraday", "~> 0"
 end

--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -151,6 +151,8 @@ module Freno
         requests = Array(request)
       end
 
+      validate_and_register_decorators(with)
+
       requests.each do |request|
         decorators[request] ||= []
         decorators[request] += Array(with)
@@ -178,6 +180,21 @@ module Freno
 
         outermost
       end
+    end
+
+    def validate_and_register_decorators(decorators)
+      decorators.each do |decorator|
+        raise DecorationError if already_registered?(decorator)
+        @registered_decorators << decorator
+      end
+    end
+
+    def already_registered?(decorator)
+      registered_decorators.include? decorator
+    end
+
+    def registered_decorators
+      @registered_decorators ||= Set.new
     end
   end
 end

--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -185,7 +185,7 @@ module Freno
     def validate_and_register_decorators(decorators)
       decorators.each do |decorator|
         raise DecorationError if already_registered?(decorator)
-        @registered_decorators << decorator
+        registered_decorators << decorator
       end
     end
 

--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -5,6 +5,7 @@ require "freno/client/requests/replication_delay"
 
 module Freno
   class Client
+    class DecorationError < StandardError; end
 
     REQUESTS = {
       check:             Requests::Check,

--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -5,7 +5,7 @@ require "freno/client/requests/replication_delay"
 
 module Freno
   class Client
-    class DecorationError < StandardError; end
+    class DecorationError < ArgumentError; end
 
     REQUESTS = {
       check:             Requests::Check,
@@ -184,7 +184,7 @@ module Freno
 
     def validate!(decorators)
       decorators.each do |decorator|
-        raise DecorationError if already_registered?(decorator)
+        raise DecorationError, "Cannot reuse decorator instance: #{decorator}" if already_registered?(decorator)
         registered_decorators << decorator
       end
     end

--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -151,7 +151,7 @@ module Freno
         requests = Array(request)
       end
 
-      validate_and_register_decorators(with)
+      validate!(with)
 
       requests.each do |request|
         decorators[request] ||= []
@@ -182,7 +182,7 @@ module Freno
       end
     end
 
-    def validate_and_register_decorators(decorators)
+    def validate!(decorators)
       decorators.each do |decorator|
         raise DecorationError if already_registered?(decorator)
         registered_decorators << decorator

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -157,7 +157,7 @@ class Freno::ClientTest < Freno::Client::Test
     decorator = Decorator.new(memo, "only_one")
     duplicate_decorator = decorator
 
-    assert_raises Freno::Client::DecorationError do
+    ex = assert_raises Freno::Client::DecorationError do
       client = Freno::Client.new(faraday) do |freno|
         freno.default_store_name         = :main
         freno.default_store_type         = :mysql
@@ -165,5 +165,6 @@ class Freno::ClientTest < Freno::Client::Test
         freno.decorate(:all, with: [decorator, duplicate_decorator])
       end
     end
+    assert /Cannot reuse decorator instance/ =~ ex.message
   end
 end

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -146,4 +146,24 @@ class Freno::ClientTest < Freno::Client::Test
     assert client.check == :ok
     assert_equal %w(first second), memo
   end
+
+  def test_decorator_instance_cannot_be_reused
+    faraday = stubbed_faraday do |stub|
+      stub.head("/check-read/github/mysql/main/0.5") { |env| [200, {}, nil] }
+      stub.head("/check/github/mysql/main") { |env| [200, {}, nil] }
+    end
+
+    memo = []
+    decorator = Decorator.new(memo, "only_one")
+    duplicate_decorator = decorator
+
+    assert_raises Freno::Client::DecorationError do
+      client = Freno::Client.new(faraday) do |freno|
+        freno.default_store_name         = :main
+        freno.default_store_type         = :mysql
+        freno.default_app                = :github
+        freno.decorate(:all, with: [decorator, duplicate_decorator])
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,8 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "faraday"
 require "freno/client"
 require "freno/throttler"
-require "mocha/mini_test"
 require "minitest/autorun"
+require "mocha/minitest"
 
 class Freno::Client::Test < Minitest::Test
 


### PR DESCRIPTION
Fixes #17 

The current behavior allows the reuse of a decorator instance, which as demonstrated in the linked issue, can caused unexpected behavior. We now check to see if a decorator is already registered, and if it is we throw an error.

Also fixed a deprecation warning in here for switching `mocha/mini_test`, to `mocha/minitest`, along with requiring it after `minitest`.