### PR TITLE
Support Freno's "low priority" flag

### DIFF
--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -47,8 +47,8 @@ module Freno
     #
     # Returns Result
     #
-    def check(app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
-      perform :check, app: app, store_type: store_type, store_name: store_name, options: options
+    def check(app: default_app, store_type: default_store_type, store_name: default_store_name, options: {})
+      perform :check, app: app, store_type: store_type, store_name: store_name, options: self.options.merge(options)
     end
 
     # Provides an interface to Freno"s check-read request
@@ -57,8 +57,8 @@ module Freno
     #
     # Returns Result
     #
-    def check_read(threshold:, app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
-      perform :check_read, app: app, store_type: store_type, store_name: store_name, threshold: threshold, options: options
+    def check_read(threshold:, app: default_app, store_type: default_store_type, store_name: default_store_name, options: {})
+      perform :check_read, app: app, store_type: store_type, store_name: store_name, threshold: threshold, options: self.options.merge(options)
     end
 
     # Implements a specific check request to retrieve the consolidated replication
@@ -68,8 +68,8 @@ module Freno
     #
     # Returns Float indicating the replication delay in seconds as reported by Freno.
     #
-    def replication_delay(app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
-      perform :replication_delay, app: app, store_type: store_type, store_name: store_name, options: options
+    def replication_delay(app: default_app, store_type: default_store_type, store_name: default_store_name, options: {})
+      perform :replication_delay, app: app, store_type: store_type, store_name: store_name, options: self.options.merge(options)
     end
 
 
@@ -77,8 +77,8 @@ module Freno
     #
     # Returns true or false.
     #
-    def check?(app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
-      check(app: app, store_type: store_type, store_name: store_name, options: options).ok?
+    def check?(app: default_app, store_type: default_store_type, store_name: default_store_name, options: {})
+      check(app: app, store_type: store_type, store_name: store_name, options: self.options.merge(options)).ok?
     end
 
     # Determines whether it"s OK to read from replicas as replication delay is below
@@ -86,8 +86,8 @@ module Freno
     #
     # Returns true or false.
     #
-    def check_read?(threshold:, app: default_app, store_type: default_store_type, store_name: default_store_name, options: self.options)
-      check_read(threshold: threshold, app: app, store_type: store_type, store_name: store_name, options: options).ok?
+    def check_read?(threshold:, app: default_app, store_type: default_store_type, store_name: default_store_name, options: {})
+      check_read(threshold: threshold, app: app, store_type: store_type, store_name: store_name, options: self.options.merge(options)).ok?
     end
 
     # Configures the client to extend the functionality of part or all the API

--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -31,6 +31,27 @@ module Freno
     #  end
     #  ```
     #
+    # Any options set on the Client are passed through to the initialization of
+    # each request:
+    #
+    #  ```ruby
+    #  freno = Freno::Client.new(faraday) do |client|
+    #    client.options = { raise_on_timeout: false }
+    #  end
+    #  ```
+    #
+    #  These default options can be overridden per request. The given options
+    #  are merged into the defaults. The request below would be performed with
+    #  the options: `{ raise_on_timeout: false, low_priority: true }`
+    #
+    #  ```ruby
+    #  freno = Freno::Client.new(faraday) do |client|
+    #    client.options = { raise_on_timeout: false }
+    #  end
+    #
+    #  freno.check?(options: { low_priority: true })
+    #  ```
+    #
     def initialize(faraday)
       @faraday            = faraday
       @default_store_type = :mysql

--- a/lib/freno/client/request.rb
+++ b/lib/freno/client/request.rb
@@ -25,7 +25,7 @@ module Freno
       end
 
       def perform
-        response = request(verb, path)
+        response = request(verb, path, params)
         process_response(response)
       rescue Faraday::TimeoutError => ex
         raise Freno::Error.new(ex) if raise_on_timeout
@@ -36,7 +36,7 @@ module Freno
 
       protected
 
-      def request(verb, path)
+      def request(verb, path, params)
         faraday.send(verb, path, params)
       end
 

--- a/lib/freno/client/request.rb
+++ b/lib/freno/client/request.rb
@@ -37,7 +37,7 @@ module Freno
       protected
 
       def request(verb, path)
-        faraday.send(verb, path)
+        faraday.send(verb, path, params)
       end
 
       def path
@@ -50,6 +50,10 @@ module Freno
         @verb || begin
           raise NotImplementedError("must be overriden in specific requests, or memoized in @verb")
         end
+      end
+
+      def params
+        @params ||= {}
       end
 
       def process_response(response)

--- a/lib/freno/client/requests/check.rb
+++ b/lib/freno/client/requests/check.rb
@@ -11,7 +11,6 @@ module Freno
           app          = kwargs.fetch(:app)
           store_type   = kwargs.fetch(:store_type)
           store_name   = kwargs.fetch(:store_name)
-          low_priority = kwargs.fetch(:low_priority, false)
 
           check do
             present app: app, store_type: store_type, store_name: store_name
@@ -21,7 +20,7 @@ module Freno
           # the p=low GET parameter is passed, the check will fail for any app
           # with failed checks within the last second. This failure is returned
           # quickly, without checking the underlying metric.
-          params[:p] = "low" if low_priority
+          params[:p] = "low" if options[:low_priority]
 
           @path = "check/#{app}/#{store_type}/#{store_name}"
         end

--- a/lib/freno/client/requests/check.rb
+++ b/lib/freno/client/requests/check.rb
@@ -8,13 +8,20 @@ module Freno
         def initialize(**kwargs)
           super
 
-          app        = kwargs.fetch(:app)
-          store_type = kwargs.fetch(:store_type)
-          store_name = kwargs.fetch(:store_name)
+          app          = kwargs.fetch(:app)
+          store_type   = kwargs.fetch(:store_type)
+          store_name   = kwargs.fetch(:store_name)
+          low_priority = kwargs.fetch(:low_priority, false)
 
           check do
             present app: app, store_type: store_type, store_name: store_name
           end
+
+          # A low priority check is handled slightly differently by Freno. If
+          # the p=low GET parameter is passed, the check will fail for any app
+          # with failed checks within the last second. This failure is returned
+          # quickly, without checking the underlying metric.
+          params[:p] = "low" if low_priority
 
           @path = "check/#{app}/#{store_type}/#{store_name}"
         end

--- a/lib/freno/client/requests/check.rb
+++ b/lib/freno/client/requests/check.rb
@@ -8,9 +8,9 @@ module Freno
         def initialize(**kwargs)
           super
 
-          app          = kwargs.fetch(:app)
-          store_type   = kwargs.fetch(:store_type)
-          store_name   = kwargs.fetch(:store_name)
+          app        = kwargs.fetch(:app)
+          store_type = kwargs.fetch(:store_type)
+          store_name = kwargs.fetch(:store_name)
 
           check do
             present app: app, store_type: store_type, store_name: store_name

--- a/lib/freno/client/requests/check_read.rb
+++ b/lib/freno/client/requests/check_read.rb
@@ -8,16 +8,23 @@ module Freno
         def initialize(**kwargs)
           super
 
-          app        = kwargs.fetch(:app)
-          store_type = kwargs.fetch(:store_type)
-          store_name = kwargs.fetch(:store_name)
-          threshold  = kwargs.fetch(:threshold)
+          app          = kwargs.fetch(:app)
+          store_type   = kwargs.fetch(:store_type)
+          store_name   = kwargs.fetch(:store_name)
+          threshold    = kwargs.fetch(:threshold)
+          low_priority = kwargs.fetch(:low_priority, false)
 
           check do
             present app: app, store_type: store_type, store_name: store_name, threshold: threshold
           end
 
-          @path = "check-read/#{app}/#{store_type}/#{store_name}/#{threshold.to_f.round(3)}"
+          # A low priority check is handled slightly differently by Freno. If
+          # the p=low GET parameter is passed, the check will fail for any app
+          # with failed checks within the last second. This failure is returned
+          # quickly, without checking the underlying metric.
+          query_string = low_priority ? "?p=low" : ""
+
+          @path = "check-read/#{app}/#{store_type}/#{store_name}/#{threshold.to_f.round(3)}#{query_string}"
         end
       end
     end

--- a/lib/freno/client/requests/check_read.rb
+++ b/lib/freno/client/requests/check_read.rb
@@ -11,7 +11,6 @@ module Freno
           app          = kwargs.fetch(:app)
           store_type   = kwargs.fetch(:store_type)
           store_name   = kwargs.fetch(:store_name)
-          low_priority = kwargs.fetch(:low_priority, false)
           threshold    = kwargs.fetch(:threshold)
 
           check do
@@ -22,7 +21,7 @@ module Freno
           # the p=low GET parameter is passed, the check will fail for any app
           # with failed checks within the last second. This failure is returned
           # quickly, without checking the underlying metric.
-          params[:p] = "low" if low_priority
+          params[:p] = "low" if options[:low_priority]
 
           @path = "check-read/#{app}/#{store_type}/#{store_name}/#{threshold.to_f.round(3)}"
         end

--- a/lib/freno/client/requests/check_read.rb
+++ b/lib/freno/client/requests/check_read.rb
@@ -11,8 +11,8 @@ module Freno
           app          = kwargs.fetch(:app)
           store_type   = kwargs.fetch(:store_type)
           store_name   = kwargs.fetch(:store_name)
-          threshold    = kwargs.fetch(:threshold)
           low_priority = kwargs.fetch(:low_priority, false)
+          threshold    = kwargs.fetch(:threshold)
 
           check do
             present app: app, store_type: store_type, store_name: store_name, threshold: threshold
@@ -22,9 +22,9 @@ module Freno
           # the p=low GET parameter is passed, the check will fail for any app
           # with failed checks within the last second. This failure is returned
           # quickly, without checking the underlying metric.
-          query_string = low_priority ? "?p=low" : ""
+          params[:p] = "low" if low_priority
 
-          @path = "check-read/#{app}/#{store_type}/#{store_name}/#{threshold.to_f.round(3)}#{query_string}"
+          @path = "check-read/#{app}/#{store_type}/#{store_name}/#{threshold.to_f.round(3)}"
         end
       end
     end

--- a/lib/freno/client/requests/check_read.rb
+++ b/lib/freno/client/requests/check_read.rb
@@ -8,10 +8,10 @@ module Freno
         def initialize(**kwargs)
           super
 
-          app          = kwargs.fetch(:app)
-          store_type   = kwargs.fetch(:store_type)
-          store_name   = kwargs.fetch(:store_name)
-          threshold    = kwargs.fetch(:threshold)
+          app        = kwargs.fetch(:app)
+          store_type = kwargs.fetch(:store_type)
+          store_name = kwargs.fetch(:store_name)
+          threshold  = kwargs.fetch(:threshold)
 
           check do
             present app: app, store_type: store_type, store_name: store_name, threshold: threshold

--- a/lib/freno/throttler.rb
+++ b/lib/freno/throttler.rb
@@ -198,10 +198,8 @@ module Freno
     end
 
     def all_stores_ok?(store_names, **options)
-      check_kwargs = { app: app }
-      check_kwargs[:options] = options if options.any?
       store_names.all? do |store_name|
-        client.check?(store_name: store_name, **check_kwargs)
+        client.check?(app: app, store_name: store_name, options: options)
       end
     rescue Freno::Error => e
       instrument(:freno_errored, store_names: store_names, error: e)

--- a/test/freno/client/requests/check_read_test.rb
+++ b/test/freno/client/requests/check_read_test.rb
@@ -45,7 +45,7 @@ class Freno::Client::Requests::CheckReadTest < Freno::Client::Test
       stub.head("/check-read/github/mysql/main/0.5?p=low") { |env| [200, {}, nil] }
     end
 
-    request = CheckRead.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", threshold: 0.5, low_priority: true)
+    request = CheckRead.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", threshold: 0.5, options: { low_priority: true })
     response = request.perform
 
     assert_equal :ok,  response.meaning

--- a/test/freno/client/requests/check_read_test.rb
+++ b/test/freno/client/requests/check_read_test.rb
@@ -40,6 +40,18 @@ class Freno::Client::Requests::CheckReadTest < Freno::Client::Test
     assert_equal 200, response.code
   end
 
+  def test_perform_calls_the_proper_service_endpoint_with_low_priority_and_succeeds
+    faraday = stubbed_faraday do |stub|
+      stub.head("/check-read/github/mysql/main/0.5?p=low") { |env| [200, {}, nil] }
+    end
+
+    request = CheckRead.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", threshold: 0.5, low_priority: true)
+    response = request.perform
+
+    assert_equal :ok,  response.meaning
+    assert_equal 200, response.code
+  end
+
   def test_perform_calls_the_proper_service_endpoint_and_fails_due_to_not_found
     faraday = stubbed_faraday do |stub|
       stub.head("/check-read/github/mysql/main/0.5") { |env| [404, {}, nil] }

--- a/test/freno/client/requests/check_test.rb
+++ b/test/freno/client/requests/check_test.rb
@@ -57,4 +57,19 @@ class Freno::Client::Requests::CheckTest < Freno::Client::Test
     assert_equal 200, response.code
     assert_equal({"StatusCode" => 200, "Value" => 0.025075, "Threshold" => 1, "Message" => ""}, response.body)
   end
+
+  def test_perform_calls_the_proper_service_endpoint_with_low_priority_and_succeeds
+    faraday = stubbed_faraday do |stub|
+      stub.head("/check/github/mysql/main?p=low") { |env| [200, {}, <<-BODY] }
+        {"StatusCode":200, "Value":0.025075, "Threshold":1, "Message":""}
+      BODY
+    end
+
+    request = Check.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", low_priority: true)
+    response = request.perform
+
+    assert_equal :ok, response.meaning
+    assert_equal 200, response.code
+    assert_equal({"StatusCode" => 200, "Value" => 0.025075, "Threshold" => 1, "Message" => ""}, response.body)
+  end
 end

--- a/test/freno/client/requests/check_test.rb
+++ b/test/freno/client/requests/check_test.rb
@@ -65,7 +65,7 @@ class Freno::Client::Requests::CheckTest < Freno::Client::Test
       BODY
     end
 
-    request = Check.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", low_priority: true)
+    request = Check.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", options: { low_priority: true })
     response = request.perform
 
     assert_equal :ok, response.meaning

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -15,7 +15,8 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?).once.with(app: :github, store_name: :mysqla)
+    stub.expects(:check?).once
+      .with(app: :github, store_name: :mysqla, options: {})
       .returns(true)
 
     throttler = Freno::Throttler.new(client: stub, app: :github)
@@ -77,7 +78,8 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?).times(2).with(app: :github, store_name: :mysqla)
+    stub.expects(:check?).times(2)
+      .with(app: :github, store_name: :mysqla, options: {})
       .returns(false).then.returns(true)
 
     throttler = Freno::Throttler.new do |t|
@@ -113,7 +115,8 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?).at_least(3).with(app: :github, store_name: :mysqla)
+    stub.expects(:check?).at_least(3)
+      .with(app: :github, store_name: :mysqla, options: {})
       .returns(false)
 
     throttler = Freno::Throttler.new do |t|

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -29,6 +29,24 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     assert block_called, "block should have been called"
   end
 
+  def test_throttle_checks_with_low_priority
+    block_called = false
+
+    stub = sample_client
+    stub.expects(:check?)
+      .once
+      .with(app: :github, store_name: :mysqla, low_priority: true)
+      .returns(true)
+
+    throttler = Freno::Throttler.new(client: stub, app: :github)
+
+    throttler.throttle(:mysqla, low_priority: true) do
+      block_called = true
+    end
+
+    assert block_called, "block should have been called"
+  end
+
   def test_throttle_runs_the_block_when_all_stores_have_caught_up
     block_called = false
 

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -11,7 +11,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     assert_match(/max_wait_seconds \(0.5\) has to be greather than wait_seconds \(1\)/, ex.message)
   end
 
-  def test_using_the_default_identiy_mapper
+  def test_using_the_default_identity_mapper
     block_called = false
 
     stub = sample_client

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -15,9 +15,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?)
-      .once
-      .with(app: :github, store_name: :mysqla)
+    stub.expects(:check?).once.with(app: :github, store_name: :mysqla)
       .returns(true)
 
     throttler = Freno::Throttler.new(client: stub, app: :github)
@@ -33,8 +31,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?)
-      .once
+    stub.expects(:check?).once
       .with(app: :github, store_name: :mysqla, options: { low_priority: true })
       .returns(true)
 
@@ -80,9 +77,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?)
-      .times(2)
-      .with(app: :github, store_name: :mysqla)
+    stub.expects(:check?).times(2).with(app: :github, store_name: :mysqla)
       .returns(false).then.returns(true)
 
     throttler = Freno::Throttler.new do |t|
@@ -118,9 +113,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?)
-      .at_least(3)
-      .with(app: :github, store_name: :mysqla)
+    stub.expects(:check?).at_least(3).with(app: :github, store_name: :mysqla)
       .returns(false)
 
     throttler = Freno::Throttler.new do |t|

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -17,7 +17,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = sample_client
     stub.expects(:check?)
       .once
-      .with(app: :github, store_name: :mysqla, low_priority: false)
+      .with(app: :github, store_name: :mysqla)
       .returns(true)
 
     throttler = Freno::Throttler.new(client: stub, app: :github)
@@ -35,7 +35,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = sample_client
     stub.expects(:check?)
       .once
-      .with(app: :github, store_name: :mysqla, low_priority: true)
+      .with(app: :github, store_name: :mysqla, options: { low_priority: true })
       .returns(true)
 
     throttler = Freno::Throttler.new(client: stub, app: :github)
@@ -82,7 +82,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = sample_client
     stub.expects(:check?)
       .times(2)
-      .with(app: :github, store_name: :mysqla, low_priority: false)
+      .with(app: :github, store_name: :mysqla)
       .returns(false).then.returns(true)
 
     throttler = Freno::Throttler.new do |t|
@@ -120,7 +120,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = sample_client
     stub.expects(:check?)
       .at_least(3)
-      .with(app: :github, store_name: :mysqla, low_priority: false)
+      .with(app: :github, store_name: :mysqla)
       .returns(false)
 
     throttler = Freno::Throttler.new do |t|

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -15,7 +15,9 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?).once.with(app: :github, store_name: :mysqla)
+    stub.expects(:check?)
+      .once
+      .with(app: :github, store_name: :mysqla, low_priority: false)
       .returns(true)
 
     throttler = Freno::Throttler.new(client: stub, app: :github)
@@ -60,7 +62,9 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?).times(2).with(app: :github, store_name: :mysqla)
+    stub.expects(:check?)
+      .times(2)
+      .with(app: :github, store_name: :mysqla, low_priority: false)
       .returns(false).then.returns(true)
 
     throttler = Freno::Throttler.new do |t|
@@ -96,7 +100,9 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     block_called = false
 
     stub = sample_client
-    stub.expects(:check?).at_least(3).with(app: :github, store_name: :mysqla)
+    stub.expects(:check?)
+      .at_least(3)
+      .with(app: :github, store_name: :mysqla, low_priority: false)
       .returns(false)
 
     throttler = Freno::Throttler.new do |t|


### PR DESCRIPTION
Freno has the ability to handle requests that specify a low priority. The difference in behavior is that a low priority request will fail the check if the app in question has any recent (within the last second) failures, regardless of the current metric value. These checks are more conservative and more performant.

See: https://github.com/github/freno/pull/91, specifically [here](https://github.com/github/freno/pull/91/files#diff-fbdc8cde28a71961e53c2e83e2483c9aR154)

Travis failures are due to unrelated Rubocop failures due to renamed cops.