### PR TITLE
Clean up the RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,182 +1,160 @@
+require: rubocop-performance
+
 AllCops:
   DisabledByDefault: true
 
 Bundler/DuplicatedGem:
   Enabled: true
-
 Bundler/OrderedGems:
+  Enabled: true
+
+Layout/BlockAlignment:
+  Enabled: true
+Layout/BlockEndNewline:
+  Enabled: true
+Layout/ConditionPosition:
+  Enabled: true
+Layout/DefEndAlignment:
+  Enabled: true
+Layout/EndAlignment:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: true
+Layout/IndentationStyle:
+  Enabled: true
+Layout/InitialIndentation:
+  Enabled: true
+Layout/LineLength:
+  Enabled: false
+Layout/SpaceAfterColon:
+  Enabled: true
+Layout/SpaceAfterComma:
+  Enabled: true
+Layout/SpaceAfterMethodName:
+  Enabled: true
+Layout/SpaceAfterNot:
+  Enabled: true
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+Layout/SpaceAroundBlockParameters:
+  Enabled: true
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+Layout/SpaceInsideParens:
+  Enabled: true
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+Layout/TrailingEmptyLines:
+  Enabled: true
+Layout/TrailingWhitespace:
   Enabled: true
 
 Lint/CircularArgumentReference:
   Enabled: true
-
 Lint/Debugger:
   Enabled: true
-
 Lint/DeprecatedClassMethods:
   Enabled: true
-
+Lint/DuplicateHashKey:
+  Enabled: true
 Lint/DuplicateMethods:
   Enabled: true
-
-Lint/DuplicatedKey:
-  Enabled: true
-
 Lint/EachWithObjectArgument:
   Enabled: true
-
 Lint/ElseLayout:
   Enabled: true
-
 Lint/EmptyEnsure:
   Enabled: true
-
-Lint/EndInMethod:
-  Enabled: true
-
 Lint/EmptyInterpolation:
   Enabled: true
-
 Lint/EnsureReturn:
   Enabled: true
-
-Lint/FloatOutOfRange:
-  Enabled: true
-
 Lint/FlipFlop:
   Enabled: true
-
+Lint/FloatOutOfRange:
+  Enabled: true
 Lint/FormatParameterMismatch:
   Enabled: true
-
-Style/HashSyntax:
-  Enabled: true
-  EnforcedStyle: ruby19
-
 Lint/LiteralInInterpolation:
   Enabled: true
-
 Lint/Loop:
   Enabled: true
-
 Lint/NextWithoutAccumulator:
   Enabled: true
-
 Lint/RandOne:
   Enabled: true
-
+Lint/RedundantSplatExpansion:
+  Enabled: true
+Lint/RedundantStringCoercion:
+  Enabled: true
 Lint/RequireParentheses:
   Enabled: true
-
 Lint/RescueException:
   Enabled: true
-
-Lint/StringConversionInInterpolation:
-  Enabled: true
-
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
-
-Lint/UnneededSplatExpansion:
-  Enabled: true
-
 Lint/UnreachableCode:
   Enabled: true
-
 Lint/UselessComparison:
   Enabled: true
-
 Lint/UselessSetterCall:
   Enabled: true
-
 Lint/Void:
   Enabled: true
 
 Metrics/AbcSize:
   Enabled: false
-
 Metrics/BlockLength:
   Enabled: false
-
 Metrics/BlockNesting:
   Enabled: false
-
 Metrics/ClassLength:
   Enabled: false
-
 Metrics/CyclomaticComplexity:
   Enabled: false
-
-Metrics/LineLength:
-  Enabled: false
-
 Metrics/MethodLength:
   Enabled: false
-
 Metrics/ModuleLength:
   Enabled: false
-
 Metrics/ParameterLists:
   Enabled: false
-
 Metrics/PerceivedComplexity:
   Enabled: false
 
 Naming/AsciiIdentifiers:
   Enabled: true
-
 Naming/ClassAndModuleCamelCase:
   Enabled: true
-
 Naming/FileName:
   Enabled: true
-
 Naming/MethodName:
   Enabled: true
 
 Performance/CaseWhenSplat:
   Enabled: false
-
 Performance/Count:
   Enabled: true
-
 Performance/Detect:
   Enabled: true
-
 Performance/DoubleStartEndWith:
   Enabled: true
-
 Performance/EndWith:
   Enabled: true
-
 Performance/FlatMap:
   Enabled: true
-
-Performance/LstripRstrip:
-  Enabled: true
-
 Performance/RangeInclude:
   Enabled: false
-
 Performance/RedundantMatch:
   Enabled: false
-
 Performance/RedundantMerge:
   Enabled: true
   MaxKeyValuePairs: 1
-
-Performance/RedundantSortBy:
-  Enabled: true
-
 Performance/ReverseEach:
   Enabled: true
-
-Performance/Sample:
-  Enabled: true
-
 Performance/Size:
   Enabled: true
-
 Performance/StartWith:
   Enabled: true
 
@@ -185,118 +163,47 @@ Security/Eval:
 
 Style/ArrayJoin:
   Enabled: true
-
 Style/BeginBlock:
   Enabled: true
-
 Style/BlockComments:
   Enabled: true
-
 Style/CaseEquality:
   Enabled: true
-
 Style/CharacterLiteral:
   Enabled: true
-
 Style/ClassMethods:
   Enabled: true
-
 Style/Copyright:
   Enabled: false
-
 Style/DefWithParentheses:
   Enabled: true
-
 Style/EndBlock:
   Enabled: true
-
 Style/For:
   Enabled: true
-
-Layout/BlockEndNewline:
+Style/HashSyntax:
   Enabled: true
-
-Layout/ConditionPosition:
-  Enabled: true
-
-Layout/EndAlignment:
-  Enabled: false
-
-Layout/EndOfLine:
-  Enabled: true
-
-Layout/InitialIndentation:
-  Enabled: true
-
+  EnforcedStyle: ruby19
 Style/LambdaCall:
   Enabled: true
-
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
-
 Style/MethodDefParentheses:
   Enabled: true
-
 Style/MultilineIfThen:
   Enabled: true
-
 Style/NilComparison:
   Enabled: true
-
 Style/Not:
   Enabled: true
-
 Style/OneLineConditional:
   Enabled: true
-
-Layout/BlockAlignment:
+Style/RedundantSortBy:
   Enabled: true
-
-Layout/DefEndAlignment:
+Style/Sample:
   Enabled: true
-
-Layout/SpaceAfterMethodName:
-  Enabled: true
-
-Layout/SpaceAfterColon:
-  Enabled: true
-
-Layout/SpaceAfterComma:
-  Enabled: true
-
-Layout/SpaceAfterNot:
-  Enabled: true
-
-Layout/SpaceAfterSemicolon:
-  Enabled: true
-
-Layout/SpaceAroundBlockParameters:
-  Enabled: true
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-
-Layout/SpaceInsideArrayPercentLiteral:
-  Enabled: true
-
-Layout/SpaceInsideParens:
-  Enabled: true
-
-Layout/SpaceInsideRangeLiteral:
-  Enabled: true
-
 Style/StabbyLambdaParentheses:
   Enabled: true
-
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/Tab:
-  Enabled: true
-
-Layout/TrailingBlankLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,16 +16,12 @@ Layout/ConditionPosition:
   Enabled: true
 Layout/DefEndAlignment:
   Enabled: true
-Layout/EndAlignment:
-  Enabled: false
 Layout/EndOfLine:
   Enabled: true
 Layout/IndentationStyle:
   Enabled: true
 Layout/InitialIndentation:
   Enabled: true
-Layout/LineLength:
-  Enabled: false
 Layout/SpaceAfterColon:
   Enabled: true
 Layout/SpaceAfterComma:
@@ -104,25 +100,6 @@ Lint/UselessSetterCall:
 Lint/Void:
   Enabled: true
 
-Metrics/AbcSize:
-  Enabled: false
-Metrics/BlockLength:
-  Enabled: false
-Metrics/BlockNesting:
-  Enabled: false
-Metrics/ClassLength:
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Enabled: false
-Metrics/MethodLength:
-  Enabled: false
-Metrics/ModuleLength:
-  Enabled: false
-Metrics/ParameterLists:
-  Enabled: false
-Metrics/PerceivedComplexity:
-  Enabled: false
-
 Naming/AsciiIdentifiers:
   Enabled: true
 Naming/ClassAndModuleCamelCase:
@@ -132,8 +109,6 @@ Naming/FileName:
 Naming/MethodName:
   Enabled: true
 
-Performance/CaseWhenSplat:
-  Enabled: false
 Performance/Count:
   Enabled: true
 Performance/Detect:
@@ -144,10 +119,6 @@ Performance/EndWith:
   Enabled: true
 Performance/FlatMap:
   Enabled: true
-Performance/RangeInclude:
-  Enabled: false
-Performance/RedundantMatch:
-  Enabled: false
 Performance/RedundantMerge:
   Enabled: true
   MaxKeyValuePairs: 1
@@ -173,8 +144,6 @@ Style/CharacterLiteral:
   Enabled: true
 Style/ClassMethods:
   Enabled: true
-Style/Copyright:
-  Enabled: false
 Style/DefWithParentheses:
   Enabled: true
 Style/EndBlock:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require: rubocop-performance
 
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.5
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 group :test do
   gem "mocha"
-  gem "rubocop", require: false
+  gem "rubocop", "~> 0.85.1", require: false
   gem "rubocop-performance", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 group :test do
   gem "mocha"
   gem "rubocop", require: false
+  gem "rubocop-performance", require: false
 end


### PR DESCRIPTION
RuboCop is failing builds on the default branch. These changes bring the RuboCop configuration up to date and change build targets to only non-EOL Ruby versions. I suggest also updating the gemspec's `required_ruby_version` but updating the gemspec is typically a task for the maintainer ahead of a new release.

**Note:** This is a refactor to pass the build. No RuboCop configurations were changed (at least, not intentionally!) and despite the new Ruby version build targets, the gem will work (at least, as well it did before!) on EOL Ruby versions.