### PR TITLE
Change the Travis badge to specify the branch and revive the dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Freno Client [![Build Status](https://travis-ci.org/github/freno-client.svg)](https://travis-ci.org/github/freno-client)
+# Freno Client [![Build Status](https://travis-ci.org/github/freno-client.svg?branch=master)](https://travis-ci.org/github/github/freno-client)
 
 A ruby client and throttling library for [Freno](https://github.com/github/freno): the cooperative, highly available throttler service.
 


### PR DESCRIPTION
Building upon: https://github.com/github/freno-client/pull/19