### PR TITLE
Fix keyword argument warnings

### DIFF
--- a/lib/freno/client.rb
+++ b/lib/freno/client.rb
@@ -163,7 +163,7 @@ module Freno
     private
 
     def perform(request, **kwargs)
-      decorated(request).perform(kwargs.merge(faraday: faraday))
+      decorated(request).perform(faraday: faraday, **kwargs)
     end
 
     def decorated(request)

--- a/lib/freno/client/request.rb
+++ b/lib/freno/client/request.rb
@@ -12,7 +12,7 @@ module Freno
       attr_reader :raise_on_timeout
 
       def self.perform(**kwargs)
-        new(kwargs).perform
+        new(**kwargs).perform
       end
 
       def initialize(**kwargs)

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -158,7 +158,7 @@ class Freno::ClientTest < Freno::Client::Test
     duplicate_decorator = decorator
 
     ex = assert_raises Freno::Client::DecorationError do
-      client = Freno::Client.new(faraday) do |freno|
+      Freno::Client.new(faraday) do |freno|
         freno.default_store_name         = :main
         freno.default_store_type         = :mysql
         freno.default_app                = :github

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -97,7 +97,7 @@ class Freno::ClientTest < Freno::Client::Test
 
     def perform(**kwargs)
       @memo << @word
-      request.perform(kwargs)
+      request.perform(**kwargs)
     end
   end
 


### PR DESCRIPTION
This passes the Travis build for Ruby head and removes Ruby warnings.