### PR TITLE
Relax the dependency on faraday

### DIFF
--- a/freno-client.gemspec
+++ b/freno-client.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0").grep_v(/^(bin|test)/)
 
-  spec.add_dependency "faraday", "~> 0"
+  spec.add_dependency "faraday", ">= 0", "< 3"
 end


### PR DESCRIPTION
Using `~> 0` prevents some clients from updating to `0.8` if they use faraday `>= 1`.

Not specifying the dependency gives us a warning during `gem build`:

```
❯ gem build
WARNING:  open-ended dependency on faraday (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
```

Using something like `~> 1` is also not great because there are still clients who use faraday `0.x.x`.

So `> 0` and `< 3` feels like a good choice to say that this client supports any available version of faraday till its next major release.