### PR TITLE
Fix lint issues on tests

### DIFF
--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -13,6 +13,7 @@ class Freno::ClientTest < Freno::Client::Test
         {"StatusCode":200,"Value":0.025173,"Threshold":1,"Message":""}
       BODY
     end
+
     assert_in_delta 0.025173, client.replication_delay, 0.0000001
   end
 
@@ -122,6 +123,7 @@ class Freno::ClientTest < Freno::Client::Test
     assert_equal %w[first second], memo
 
     memo.clear
+
     assert client.check == :ok
     assert_equal [], memo
   end
@@ -145,6 +147,7 @@ class Freno::ClientTest < Freno::Client::Test
     assert_equal %w[first second], memo
 
     memo.clear
+
     assert client.check == :ok
     assert_equal %w[first second], memo
   end
@@ -167,6 +170,7 @@ class Freno::ClientTest < Freno::Client::Test
         freno.decorate(:all, with: [decorator, duplicate_decorator])
       end
     end
+
     assert_match "Cannot reuse decorator instance", ex.message
   end
 
@@ -190,6 +194,7 @@ class Freno::ClientTest < Freno::Client::Test
     assert_equal %w[only], memo
 
     memo.clear
+
     assert client.check == :ok
     assert_equal %w[only], memo
   end

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -7,6 +7,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     ex = assert_raises(ArgumentError) do
       Freno::Throttler.new(wait_seconds: 1, max_wait_seconds: 0.5)
     end
+
     assert_includes ex.message, "app must be provided"
     assert_includes ex.message, "client must be provided"
     assert_includes ex.message, "max_wait_seconds (0.5) has to be greather than wait_seconds (1)"
@@ -59,6 +60,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     throttler.throttle(:wadus) do
       block_called = true
     end
+
     assert block_called, "block should have been called"
 
     assert_equal 1, throttler.instrumenter.count("throttler.called")
@@ -98,10 +100,12 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     assert block_called, "block should have been called"
 
     called_events = throttler.instrumenter.events_for("throttler.called")
+
     assert_equal 1, called_events.count
     assert_equal [:mysqla], called_events.first[:store_names]
 
     waited_events = throttler.instrumenter.events_for("throttler.waited")
+
     assert_equal 1, waited_events.count
     assert_equal [:mysqla], waited_events.first[:store_names]
     assert_in_delta 0.5, waited_events.first[:waited], 0.01
@@ -187,6 +191,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
 
     freno_errored_events =
       throttler.instrumenter.events_for("throttler.freno_errored")
+
     assert_equal 1, freno_errored_events.count
     assert_equal [:mysqla], freno_errored_events.first[:store_names]
     assert_kind_of Freno::Error, freno_errored_events.first[:error]
@@ -232,6 +237,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
 
     circuit_breaker_events =
       throttler.instrumenter.events_for("throttler.circuit_open")
+
     assert_equal 1, circuit_breaker_events.count
     assert_equal [:mysqla], circuit_breaker_events.first[:store_names]
     assert_equal 0, circuit_breaker_events.first[:waited]


### PR DESCRIPTION
# Overview
This PR fixes the current lint issues on the tests.

## Issue 
Running `bin/test` outputs a series of correctable issues:
```
% bin/test
# Running:

.....................................

Finished in 0.005708s, 6482.1304 runs/s, 24702.1727 assertions/s.

37 runs, 141 assertions, 0 failures, 0 errors, 0 skips
Running RuboCop...
Inspecting 26 files
.......................CC.

Offenses:

test/freno/client_test.rb:16:5: C: [Correctable] Minitest/EmptyLineBeforeAssertionMethods: Add empty line before assertion.
    assert_in_delta 0.025173, client.replication_delay, 0.0000001
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/freno/client_test.rb:125:5: C: [Correctable] Minitest/EmptyLineBeforeAssertionMethods: Add empty line before assertion.
    assert client.check == :ok
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
test/freno/client_test.rb:148:5: C: [Correctable] Minitest/EmptyLineBeforeAssertionMethods: Add empty line before assertion.
    assert client.check == :ok
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
...
```
Changes were done with rubocop autofix feature
