### PR TITLE
Fix regression from capturing StopIteration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,7 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/SymbolArray:
   Enabled: false
+Style/InfiniteLoop:
+  Enabled: false
+Style/Next:
+  Enabled: false

--- a/lib/freno/throttler.rb
+++ b/lib/freno/throttler.rb
@@ -175,7 +175,7 @@ module Freno
         if all_stores_ok?(store_names, **options)
           instrument(:succeeded, store_names: store_names, waited: waited)
           circuit_breaker.success
-          return yield
+          break
         end
 
         wait
@@ -188,6 +188,8 @@ module Freno
         circuit_breaker.failure
         raise WaitedTooLong.new(waited_seconds: waited, max_wait_seconds: max_wait_seconds)
       end
+
+      yield
     end
 
     private

--- a/lib/freno/throttler.rb
+++ b/lib/freno/throttler.rb
@@ -166,7 +166,7 @@ module Freno
       instrument(:called, store_names: store_names)
       waited = 0
 
-      loop do
+      while true
         unless circuit_breaker.allow_request?
           instrument(:circuit_open, store_names: store_names, waited: waited)
           raise CircuitOpen
@@ -182,11 +182,11 @@ module Freno
         waited += wait_seconds
         instrument(:waited, store_names: store_names, waited: waited, max: max_wait_seconds)
 
-        next unless waited > max_wait_seconds
-
-        instrument(:waited_too_long, store_names: store_names, waited: waited, max: max_wait_seconds)
-        circuit_breaker.failure
-        raise WaitedTooLong.new(waited_seconds: waited, max_wait_seconds: max_wait_seconds)
+        if waited > max_wait_seconds
+          instrument(:waited_too_long, store_names: store_names, waited: waited, max: max_wait_seconds)
+          circuit_breaker.failure
+          raise WaitedTooLong.new(waited_seconds: waited, max_wait_seconds: max_wait_seconds)
+        end
       end
 
       yield

--- a/test/freno/client/requests/check_read_test.rb
+++ b/test/freno/client/requests/check_read_test.rb
@@ -68,8 +68,8 @@ class Freno::Client::Requests::CheckReadTest < Freno::Client::Test
     request = CheckRead.new(faraday: faraday, app: "github", store_type: "mysql", store_name: "main", threshold: 0.5)
     response = request.perform
 
-    assert response == :not_found
-    assert response == 404
+    assert_operator response, :==, :not_found
+    assert_operator response, :==, 404
 
     assert_equal :not_found, response.meaning
     assert_equal 404, response.code

--- a/test/freno/client_test.rb
+++ b/test/freno/client_test.rb
@@ -13,6 +13,7 @@ class Freno::ClientTest < Freno::Client::Test
         {"StatusCode":200,"Value":0.025173,"Threshold":1,"Message":""}
       BODY
     end
+
     assert_in_delta 0.025173, client.replication_delay, 0.0000001
   end
 
@@ -21,8 +22,8 @@ class Freno::ClientTest < Freno::Client::Test
       stub.head("/check/github/mysql/main") { |_env| [200, {}, nil] }
     end
 
-    assert client.check == :ok
-    assert client.check == 200
+    assert_operator client.check, :==, :ok
+    assert_operator client.check, :==, 200
     assert client.check?
   end
 
@@ -31,8 +32,8 @@ class Freno::ClientTest < Freno::Client::Test
       stub.head("/check/github/mysql/main") { |_env| [500, {}, nil] }
     end
 
-    assert client.check == :internal_server_error
-    assert client.check == 500
+    assert_operator client.check, :==, :internal_server_error
+    assert_operator client.check, :==, 500
     refute client.check?
   end
 
@@ -41,8 +42,8 @@ class Freno::ClientTest < Freno::Client::Test
       stub.head("/check-read/github/mysql/main/0.5") { |_env| [200, {}, nil] }
     end
 
-    assert client.check_read(threshold: 0.5) == :ok
-    assert client.check_read(threshold: 0.5) == 200
+    assert_operator client.check_read(threshold: 0.5), :==, :ok
+    assert_operator client.check_read(threshold: 0.5), :==, 200
     assert client.check_read?(threshold: 0.5)
   end
 
@@ -51,8 +52,8 @@ class Freno::ClientTest < Freno::Client::Test
       stub.head("/check-read/github/mysql/main/0.5") { |_env| [500, {}, nil] }
     end
 
-    assert client.check_read(threshold: 0.5) == :internal_server_error
-    assert client.check_read(threshold: 0.5) == 500
+    assert_operator client.check_read(threshold: 0.5), :==, :internal_server_error
+    assert_operator client.check_read(threshold: 0.5), :==, 500
     refute client.check_read?(threshold: 0.5)
   end
 
@@ -86,7 +87,7 @@ class Freno::ClientTest < Freno::Client::Test
       freno.options[:raise_on_timeout] = false
     end
 
-    assert client.check_read(threshold: 0.5) == :request_timeout
+    assert_operator client.check_read(threshold: 0.5), :==, :request_timeout
   end
 
   class Decorator
@@ -118,11 +119,12 @@ class Freno::ClientTest < Freno::Client::Test
       freno.decorate(:check_read, with: [Decorator.new(memo, "first"), Decorator.new(memo, "second")])
     end
 
-    assert client.check_read(threshold: 0.5) == :ok
+    assert_operator client.check_read(threshold: 0.5), :==, :ok
     assert_equal %w[first second], memo
 
     memo.clear
-    assert client.check == :ok
+
+    assert_operator client.check, :==, :ok
     assert_equal [], memo
   end
 
@@ -141,11 +143,12 @@ class Freno::ClientTest < Freno::Client::Test
       freno.decorate(:all, with: [Decorator.new(memo, "first"), Decorator.new(memo, "second")])
     end
 
-    assert client.check_read(threshold: 0.5) == :ok
+    assert_operator client.check_read(threshold: 0.5), :==, :ok
     assert_equal %w[first second], memo
 
     memo.clear
-    assert client.check == :ok
+
+    assert_operator client.check, :==, :ok
     assert_equal %w[first second], memo
   end
 
@@ -186,11 +189,12 @@ class Freno::ClientTest < Freno::Client::Test
       freno.decorate(:all, with: decorator)
     end
 
-    assert client.check_read(threshold: 0.5) == :ok
+    assert_operator client.check_read(threshold: 0.5), :==, :ok
     assert_equal %w[only], memo
 
     memo.clear
-    assert client.check == :ok
+
+    assert_operator client.check, :==, :ok
     assert_equal %w[only], memo
   end
 end

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -59,6 +59,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     throttler.throttle(:wadus) do
       block_called = true
     end
+
     assert block_called, "block should have been called"
 
     assert_equal 1, throttler.instrumenter.count("throttler.called")
@@ -98,10 +99,12 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     assert block_called, "block should have been called"
 
     called_events = throttler.instrumenter.events_for("throttler.called")
+
     assert_equal 1, called_events.count
     assert_equal [:mysqla], called_events.first[:store_names]
 
     waited_events = throttler.instrumenter.events_for("throttler.waited")
+
     assert_equal 1, waited_events.count
     assert_equal [:mysqla], waited_events.first[:store_names]
     assert_in_delta 0.5, waited_events.first[:waited], 0.01
@@ -149,7 +152,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     assert_equal 1, waited_too_long_events.count
     assert_equal [:mysqla], waited_too_long_events.first[:store_names]
     assert_in_delta 0.3, waited_too_long_events.first[:max], 0.01
-    assert waited_too_long_events.first[:waited] >= 0.3
+    assert_operator waited_too_long_events.first[:waited], :>=, 0.3
 
     assert_equal 0, throttler.instrumenter.count("throttler.freno_errored")
     assert_equal 0, throttler.instrumenter.count("throttler.circuit_open")
@@ -187,6 +190,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
 
     freno_errored_events =
       throttler.instrumenter.events_for("throttler.freno_errored")
+
     assert_equal 1, freno_errored_events.count
     assert_equal [:mysqla], freno_errored_events.first[:store_names]
     assert_kind_of Freno::Error, freno_errored_events.first[:error]
@@ -232,6 +236,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
 
     circuit_breaker_events =
       throttler.instrumenter.events_for("throttler.circuit_open")
+
     assert_equal 1, circuit_breaker_events.count
     assert_equal [:mysqla], circuit_breaker_events.first[:store_names]
     assert_equal 0, circuit_breaker_events.first[:waited]

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -236,4 +236,13 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     assert_equal [:mysqla], circuit_breaker_events.first[:store_names]
     assert_equal 0, circuit_breaker_events.first[:waited]
   end
+
+  def test_does_not_swallow_stop_iteration
+    throttler = Freno::Throttler.new(client: sample_client, app: :github)
+    assert_raises(StopIteration) do
+      throttler.throttle do
+        raise StopIteration
+      end
+    end
+  end
 end


### PR DESCRIPTION
cc @laserlemon I see this will conflict with #30

We encountered a bug when upgradaing where loop captures the StopIteration exception, whereas a plain while loop does not. This commit fixes this regression by breaking from the loop before yielding.

It's better for us to break out of the loop anyways before yielding both to make control flow more obvious and to remove a confusing loop frame from stacktraces.


Following Style/InfiniteLoop introduced a regression because it's an unsafe change, so we should not apply this in the future. There's no problem with while loops and we should be comfortable using them. Style/Next didn't cause a behaviour change, but the resulting code was much harder to read.

Rubocop's rules aren't inherently virtuous, IMO we should write code in a way that works the best and is the best for humans to read rather than following an arbitrary set of rules. Given that these two rules failed us here, let's not attempt to apply them elsewhere either.